### PR TITLE
feat(tx): relation between user, order, and transaction

### DIFF
--- a/src/main/java/com/learn/main/transaction/Transaction.java
+++ b/src/main/java/com/learn/main/transaction/Transaction.java
@@ -19,33 +19,39 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 public class Transaction implements Serializable {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "transaction_seq")
-    @SequenceGenerator(name = "transaction_seq", allocationSize = 1)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "transaction_seq")
+  @SequenceGenerator(name = "transaction_seq", allocationSize = 1)
+  private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private User user;
+  @Column(columnDefinition = "varchar(100)")
+  private String code;
 
-    @ManyToOne(fetch = FetchType.EAGER, optional = false)
-    @JoinColumn(name = "order_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    private Order order;
+  @Column(columnDefinition = "smallint")
+  private Integer type;
 
-    @Column(columnDefinition = "varchar(100)")
-    private String code;
-    @Column(columnDefinition = "smallint")
-    private Integer type;
-    @Column(columnDefinition = "smallint")
-    private Integer mode;
-    @Column(columnDefinition = "smallint")
-    private Integer status;
-    @Column(columnDefinition = "text")
-    private String content;
-    @JdbcTypeCode(SqlTypes.TIMESTAMP_WITH_TIMEZONE)
-    private ZonedDateTime createdAt;
-    @JdbcTypeCode(SqlTypes.TIMESTAMP_WITH_TIMEZONE)
-    private ZonedDateTime updatedAt;
+  @Column(columnDefinition = "smallint")
+  private Integer mode;
+
+  @Column(columnDefinition = "smallint")
+  private Integer status;
+
+  @Column(columnDefinition = "text")
+  private String content;
+
+  @JdbcTypeCode(SqlTypes.TIMESTAMP_WITH_TIMEZONE)
+  private ZonedDateTime createdAt;
+
+  @JdbcTypeCode(SqlTypes.TIMESTAMP_WITH_TIMEZONE)
+  private ZonedDateTime updatedAt;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private User user;
+
+  @ManyToOne(fetch = FetchType.EAGER, optional = false)
+  @JoinColumn(name = "order_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Order order;
 }

--- a/src/main/java/com/learn/main/transaction/TransactionController.java
+++ b/src/main/java/com/learn/main/transaction/TransactionController.java
@@ -1,21 +1,70 @@
 package com.learn.main.transaction;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/inventory/transactions")
 public class TransactionController {
 
-    private final TransactionService transactionService;
+  private final TransactionService transactionService;
 
-    public TransactionController(TransactionService transactionService) {
-        this.transactionService = transactionService;
-    }
+  public TransactionController(TransactionService transactionService) {
+    this.transactionService = transactionService;
+  }
 
-    @GetMapping
-    public String getProducts() {
-        return this.transactionService.getTransaction();
+  @GetMapping
+  public ResponseEntity<List<Transaction>> getTransaction(
+      @RequestParam(defaultValue = "0") Integer page,
+      @RequestParam(defaultValue = "10") Integer size,
+      @RequestParam(defaultValue = "ASC") String orderBy) {
+    try {
+      List<Transaction> transactions = this.transactionService.getTransactions(page, size, orderBy);
+      return new ResponseEntity<>(transactions, HttpStatus.OK);
+    } catch (Exception e) {
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<List<Transaction>> getTransactionByUserId(
+      @PathVariable(name = "userId") Long userId) {
+    try {
+      List<Transaction> transactions = this.transactionService.getTransactionByUserId(userId);
+      return new ResponseEntity<>(transactions, HttpStatus.OK);
+    } catch (Exception e) {
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GetMapping("/{transactionId}")
+  public ResponseEntity<Transaction> getTransactionById(
+      @PathVariable(name = "transactionId") Long transactionId) {
+    try {
+      Transaction transaction = this.transactionService.getTransactionById(transactionId);
+      if (transaction != null) {
+        return new ResponseEntity<>(transaction, HttpStatus.OK);
+      }
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    } catch (Exception e) {
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @PutMapping("/{transactionId}")
+  public ResponseEntity<Transaction> updateTransactionById(
+      @PathVariable(name = "transactionId") Long transactionId,
+      @RequestBody Transaction updateBody) {
+    try {
+      Transaction updateOrigin = transactionService.updateTransaction(transactionId, updateBody);
+      return new ResponseEntity<>(updateOrigin, HttpStatus.OK);
+    } catch (Exception e) {
+      return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
 }

--- a/src/main/java/com/learn/main/transaction/TransactionRepository.java
+++ b/src/main/java/com/learn/main/transaction/TransactionRepository.java
@@ -1,0 +1,12 @@
+package com.learn.main.transaction;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+  Optional<List<Transaction>> findByUserId(Long userId);
+}

--- a/src/main/java/com/learn/main/transaction/TransactionRespository.java
+++ b/src/main/java/com/learn/main/transaction/TransactionRespository.java
@@ -1,6 +1,0 @@
-package com.learn.main.transaction;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TransactionRespository extends JpaRepository<Transaction, Long> {
-}

--- a/src/main/java/com/learn/main/transaction/TransactionService.java
+++ b/src/main/java/com/learn/main/transaction/TransactionService.java
@@ -1,11 +1,82 @@
 package com.learn.main.transaction;
 
+import com.learn.helper.DatabaseHelper;
+import com.learn.main.order.Order;
+import com.learn.main.user.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
 @Service
 public class TransactionService {
 
-    public String getTransaction() {
-        return "Get transaction";
+  private final TransactionRepository transactionRepository;
+
+  public TransactionService(TransactionRepository transactionRepository) {
+    this.transactionRepository = transactionRepository;
+  }
+
+  public List<Transaction> getTransactions(Integer page, Integer size, String orderBy) {
+    try {
+      Pageable pageable = DatabaseHelper.initPageableWithSort(page, size, orderBy);
+      Page<Transaction> transactionPage = transactionRepository.findAll(pageable);
+      return transactionPage.getContent();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  public List<Transaction> getTransactionByUserId(Long userId) {
+    try {
+      Optional<List<Transaction>> transactions = transactionRepository.findByUserId(userId);
+      return transactions.orElse(List.of());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Transaction getTransactionById(Long transactionId) {
+    try {
+      Optional<Transaction> transaction = transactionRepository.findById(transactionId);
+      return transaction.orElse(null);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void createNewTransaction(Transaction transaction) {
+    try {
+      transaction.setCreatedAt(ZonedDateTime.now());
+      transaction.setUpdatedAt(ZonedDateTime.now());
+      transactionRepository.save(transaction);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Transaction updateTransaction(Long transactionId, Transaction updateBody) {
+    try {
+      Optional<Transaction> origin = transactionRepository.findById(transactionId);
+      if (origin.isPresent()) {
+        Transaction oldTransaction = origin.get();
+        oldTransaction.setCode(updateBody.getCode());
+        oldTransaction.setType(updateBody.getType());
+        oldTransaction.setMode(updateBody.getMode());
+        oldTransaction.setStatus(updateBody.getStatus());
+        oldTransaction.setContent(updateBody.getContent());
+        oldTransaction.setUpdatedAt(ZonedDateTime.now());
+        return transactionRepository.save(oldTransaction);
+      } else {
+        return transactionRepository.save(updateBody);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 }


### PR DESCRIPTION
When user create order, it will initiate transaction for track user payment process such as `pending`, `processing`, `completed`, and `cancel. 
- Create transaction automatic when user create order
- Transaction sometime would be updated by bank status, so we should expose API path to update status of transaction
- Admin user can see transaction information and status
- When user want to cancel order, It wouldn't be delete information from database, It must insert `cancel` status instead of delete info.

Update: transaction service